### PR TITLE
fix for range check error

### DIFF
--- a/Bcrypt.pas
+++ b/Bcrypt.pas
@@ -499,7 +499,8 @@ begin
 
 		Result := TBCrypt.CryptCore(cost, key, salt);
 	finally
-		ZeroMemory(@key[0], Length(key));
+		if Length(key) > 0 then
+			ZeroMemory(@key[0], Length(key));
 	end;
 end;
 


### PR DESCRIPTION
When calling TBCrypt.CheckPassword with empty string as password there was a range check error on ZeroMemory().