### PR TITLE
Update Bcrypt.pas

### DIFF
--- a/Bcrypt.pas
+++ b/Bcrypt.pas
@@ -314,7 +314,8 @@ type
 
 const
 	CP_UTF8 = 65001;
-
+	{$EXTERNALSYM CP_UTF8}
+	
 type
 	TBCrypt = class(TObject)
 	private
@@ -501,7 +502,7 @@ const
 {
 	TODO: bcrypt with SHA256 pre-hashing
 
-	passlib.hash.bcrypt_sha256 - BCrypt+SHA256¶
+	passlib.hash.bcrypt_sha256 - BCrypt+SHA256Â¶
 	https://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt_sha256.html
 
 	BCrypt was developed to replace md5_crypt for BSD systems. It uses a modified version of the Blowfish stream cipher.
@@ -2104,8 +2105,8 @@ begin
 
 		SASLprep (rfc4013), like StringPrep (rfc3454) both specified NFKC:
 
-			Before: Noe¨l
-			After:  Noël
+			Before: NoeÂ¨l
+			After:  NoÃ«l
 
 		Spaces
 		======
@@ -2610,20 +2611,20 @@ const
 			//http://stackoverflow.com/a/7031942/12597
 begin
 	{
-		Before: A + ¨ + fi + n
+		Before: A + Â¨ + fi + n
 				A:  U+0041
-				¨:  U+0308 Combining Diaeresis
+				Â¨:  U+0308 Combining Diaeresis
 				fi: U+FB01 Latin Small Ligature Fi
 				n:  U+006E
 
-		Normalized:  Ä + f + i + n
-				Ä:  U+00C4  Latin Capital Letter A with Diaeresis
+		Normalized:  Ã„ + f + i + n
+				Ã„:  U+00C4  Latin Capital Letter A with Diaeresis
 				f:  U+0066
 				i:  U+0069
 				n:  U+006E
 
 		Final UTF-8:
-				Ä:  0xC3 0x84
+				Ã„:  0xC3 0x84
 				f:  0x66
 				i:  0x69
 				n:  0x6E
@@ -2673,12 +2674,12 @@ begin
 
 		Original
 				A:  U+0041
-				¨:  U+0308 Combining Diaeresis
+				Â¨:  U+0308 Combining Diaeresis
 				fi: U+FB01 Latin Small Ligature Fi
 				n:  U+006E
 
-		Normalized:  Ä + f + i + n
-				Ä:  U+00C4  Latin Capital Letter A with Diaeresis
+		Normalized:  Ã„ + f + i + n
+				Ã„:  U+00C4  Latin Capital Letter A with Diaeresis
 				f:  U+0066
 				i:  U+0069
 				n:  U+006E
@@ -3304,3 +3305,4 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 }
 end.
+


### PR DESCRIPTION
C++Builder does not need to see the definition of CP_UTF8. The EXTERNALSYM directive tells the compiler not to generated code for this symbol in Bcrypt.hpp.

The way CP_UTF8 is defined causes an error as wel with the 32-bit Clang compiler: [C++ Error] Bcrypt.hpp(132, 34):  expected unqualified-id. Not generating the definition makes this a non-issue. 

I only added a single line but something in the text makes it look like 12 lines were changed.